### PR TITLE
temporary add plymouth blankon

### DIFF
--- a/config/package-lists/live.list.chroot
+++ b/config/package-lists/live.list.chroot
@@ -15,4 +15,4 @@ fonts-indic
 fonts-thai-tlwg
 fonts-noto-cjk
 sudo
-
+plymouth-theme-blankon


### PR DESCRIPTION
mungkin nanti `plymouth-theme-blankon` dijadikan sebagai dependensi paket branding (`blankon-desktop` mungkin?)

terkait: https://github.com/BlankOn/Verbeek/issues/236